### PR TITLE
Fix monthly gauges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.5-alpine3.8 AS builder
+FROM golang:1.14.9-alpine AS builder
 
 RUN apk add --update --no-cache git ca-certificates
 

--- a/cmd/sendgrid-exporter/main.go
+++ b/cmd/sendgrid-exporter/main.go
@@ -676,7 +676,7 @@ func collectMetrics(aggregadedby string) ([]*Statistics, error) {
 	case http.StatusOK:
 		// do nothing
 	case http.StatusTooManyRequests:
-		return nil, fmt.Errorf("ireached API rate limit")
+		return nil, fmt.Errorf("reached API rate limit")
 	default:
 		return nil, fmt.Errorf("invalid request")
 	}

--- a/cmd/sendgrid-exporter/main.go
+++ b/cmd/sendgrid-exporter/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jinzhu/now"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/version"
@@ -639,22 +640,29 @@ type Statistics struct {
 	Stats []*Stat `json:"stats,omitempty"`
 }
 
-func collectMetrics(aggregadedby string) ([]*Statistics, error) {
-
+func collectMetrics(aggregated_by string) ([]*Statistics, error) {
 	u, err := url.Parse("https://api.sendgrid.com/v3/stats")
 	if err != nil {
 		return nil, err
 	}
 
-	today := time.Now().Format("2006-01-02")
-
 	query := url.Values{}
-	start := today     // YYYY-MM-DD
-	end := today       // YYYY-MM-DD
-	by := aggregadedby //"day"    // day|week|month
-	query.Set("start_date", start)
-	query.Set("end_date", end)
-	query.Set("aggregated_by", by)
+	end_date := time.Now().Format("2006-01-02") // YYYY-MM-DD
+
+	var start_date string
+	if aggregated_by == "day" {
+		start_date = end_date
+	} else if aggregated_by == "week" {
+		start_date = now.BeginningOfWeek().Format("2006-01-02")
+	} else if aggregated_by == "month" {
+		start_date = now.BeginningOfMonth().Format("2006-01-02")
+	} else {
+		return nil, fmt.Errorf("Expected aggregated_by param to be one of \"day\", \"week\", and \"month\" but was %s", aggregated_by)
+	}
+
+	query.Set("start_date", start_date)
+	query.Set("end_date", end_date)
+	query.Set("aggregated_by", aggregated_by)
 	u.RawQuery = query.Encode()
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)

--- a/cmd/sendgrid-exporter/main.go
+++ b/cmd/sendgrid-exporter/main.go
@@ -23,9 +23,9 @@ var (
 )
 
 var (
-        listenAddr      = os.Getenv("LISTEN_ADDR")
-        metricsEndpoint = os.Getenv("METRICS_ENDPOINT")
-        apiKey          = os.Getenv("SENDGRID_API_KEY")
+	listenAddr      = os.Getenv("LISTEN_ADDR")
+	metricsEndpoint = os.Getenv("METRICS_ENDPOINT")
+	apiKey          = os.Getenv("SENDGRID_API_KEY")
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module gitlab.com/riccardopomato/sendgrid-statistics-exporter
 
+go 1.14
+
 require (
-	github.com/prometheus/client_golang v0.9.2 // indirect
-	github.com/prometheus/common v0.2.0 // indirect
+	github.com/prometheus/client_golang v0.9.2
+	github.com/prometheus/common v0.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gitlab.com/riccardopomato/sendgrid-statistics-exporter
 go 1.14
 
 require (
+	github.com/jinzhu/now v1.1.1
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/common v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/jinzhu/now v1.1.1 h1:g39TucaRWyV3dwDO++eEc6qf8TVIQ/Da48WmqjZ3i7E=
+github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=


### PR DESCRIPTION
Due to the `start_date` and `end_date` previously always being equal to today, the monthly gauges couldn't gather information on the current month.

This Pull Request changes the value of `start_date` to the first day of the month (resp. week) when using monthly (resp. weekly) gauges.

Output example (previously, we would have had sendgrid_dailydelivered=sendgrid_monthlydelivered):

```
curl http://127.0.0.1:18080/metrics
[...]
# HELP sendgrid_dailydelivered dailydelivered
# TYPE sendgrid_dailydelivered gauge
sendgrid_dailydelivered{name="",type=""} 52363
[...]
# HELP sendgrid_monthlydelivered monthlydelivered
# TYPE sendgrid_monthlydelivered gauge
sendgrid_monthlydelivered{name="",type=""} 221137
[...]
```

Additionally, the first 3 commits contain maintenance updates (formatting, docker image).